### PR TITLE
Add default_resources for events permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ EOF
     lambda = {
       lambda = ["arn:aws:lambda:eu-west-1:123456789012:function:test1", "arn:aws:lambda:eu-west-1:123456789012:function:test2"]
     }
+
+    stepfunction_Sync = {
+      stepfunction = ["arn:aws:states:eu-west-1:123456789012:stateMachine:test1"]
+      stepfunction_Wildcard = ["arn:aws:states:eu-west-1:123456789012:stateMachine:test1"]
+
+      # Set to true to use the default events (otherwise, set this to a list of ARNs; see the docs linked in locals.tf
+      # for more information). Without events permissions, you will get an error similar to this:
+      #   Error: AccessDeniedException: 'arn:aws:iam::xxxx:role/step-functions-role' is not authorized to
+      #   create managed-rule
+      events = true
+    }
   }
 
   type = "STANDARD"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -66,6 +66,17 @@ module "step_function" {
       xray = true
     }
 
+    stepfunction_Sync = {
+      stepfunction = ["arn:aws:states:eu-west-1:123456789012:stateMachine:test1"]
+      stepfunction_Wildcard = ["arn:aws:states:eu-west-1:123456789012:stateMachine:test1"]
+
+      # Set to true to use the default events (otherwise, set this to a list of ARNs; see the docs linked in locals.tf
+      # for more information). Without events permissions, you will get an error similar to this:
+      #   Error: AccessDeniedException: 'arn:aws:iam::xxxx:role/step-functions-role' is not authorized to
+      #   create managed-rule
+      events = true
+    }
+
     #    # NB: This will "Deny" everything (including logging)!
     #    no_tasks = {
     #      deny_all = true

--- a/locals.tf
+++ b/locals.tf
@@ -211,6 +211,7 @@ locals {
           "events:DescribeRule"
         ]
       }
+      default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"]
     }
 
     batch_WaitForTaskToken = {
@@ -269,6 +270,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForECSTaskRule"]
       }
     }
 
@@ -352,6 +354,7 @@ locals {
           "events:DescribeRule"
         ]
       }
+      default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForSageMakerTrainingJobsRule"]
     }
 
     sagemaker_CreateTrainingJob_WaitForTaskToken = {
@@ -417,6 +420,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForSageMakerTransformJobsRule"]
       }
     }
 
@@ -464,6 +468,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventForEMRAddJobFlowStepsRule"]
       }
     }
 
@@ -497,6 +502,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventForEMRRunJobFlowRule"]
       }
     }
 
@@ -541,6 +547,7 @@ locals {
           "events:DescribeRule"
         ]
       }
+      default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventForEMRTerminateJobFlowsRule"]
     }
 
     # https://docs.aws.amazon.com/step-functions/latest/dg/codebuild-iam.html
@@ -560,6 +567,7 @@ locals {
           "events:DescribeRule"
         ]
       }
+      default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventForCodeBuildStartBuildRule"]
     }
 
     codebuild_StartBuild = {

--- a/locals.tf
+++ b/locals.tf
@@ -711,6 +711,7 @@ locals {
           "events:PutRule",
           "events:DescribeRule"
         ]
+        default_resources = ["arn:aws:events:${local.aws_region}:${data.aws_caller_identity.current.account_id}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule"]
       }
     }
 

--- a/locals.tf
+++ b/locals.tf
@@ -744,3 +744,5 @@ locals {
 
   }
 }
+
+data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This PR adds he relevant `default_resources` to each `events` block inside the `aws_service_policies` such that users
can write `events = true` for services that require these permissions. I have tested the step functions `default_resources`,
as that is what I use in my projects, but I don't have a way to test the other `default_resources` right now.

Fixes #33.